### PR TITLE
Fix button size on some environments

### DIFF
--- a/src/NavTable/ui/main_panel.ui
+++ b/src/NavTable/ui/main_panel.ui
@@ -75,7 +75,7 @@
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout_4">
          <item>
-          <widget class="QPushButton" name="orderByBT">
+          <widget class="QToolButton" name="orderByBT">
            <property name="maximumSize">
             <size>
              <width>23</width>
@@ -97,7 +97,7 @@
           </widget>
          </item>
          <item>
-          <widget class="QPushButton" name="removeFilterBT">
+          <widget class="QToolButton" name="removeFilterBT">
            <property name="maximumSize">
             <size>
              <width>23</width>
@@ -119,10 +119,16 @@
           </widget>
          </item>
          <item>
-          <widget class="QPushButton" name="formFilterBT">
+          <widget class="QToolButton" name="formFilterBT">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
            <property name="maximumSize">
             <size>
-             <width>23</width>
+             <width>40</width>
              <height>40</height>
             </size>
            </property>
@@ -141,7 +147,7 @@
           </widget>
          </item>
          <item>
-          <widget class="QPushButton" name="exprFilterBT">
+          <widget class="QToolButton" name="exprFilterBT">
            <property name="maximumSize">
             <size>
              <width>23</width>
@@ -186,7 +192,7 @@
           <x>0</x>
           <y>0</y>
           <width>404</width>
-          <height>69</height>
+          <height>70</height>
          </rect>
         </property>
        </widget>


### PR DESCRIPTION
I change buttons from QPushButton to QToolButton and set the same size for height and width. 

I think that this resolves the problem reported in #6 but i don´t test them. I try NavTable on Windows, Kubuntu, Linux mint and Ubuntu Mate and i don´t see any problem with icon size.